### PR TITLE
removed psycopg2 from requirements

### DIFF
--- a/server/serverpl/requirements.txt
+++ b/server/serverpl/requirements.txt
@@ -15,7 +15,6 @@ markdown
 mkdocs
 mock
 oauth2
-psycopg2
 pydenticon
 pytest
 pytest-django


### PR DESCRIPTION
It prevents the installation of PL if postgresql is not installed