### PR TITLE
Fix dashboard with no groups

### DIFF
--- a/apps/activity/templates/activity/activity_type/course/teacher_dashboard.html
+++ b/apps/activity/templates/activity/activity_type/course/teacher_dashboard.html
@@ -7,7 +7,7 @@
     <ion-card-header>
         <ion-card-title>{{ name }}</ion-card-title>
     </ion-card-header>
-    {% if len(groups) > 0 %}
+    {% if groups %}
     <form action="/activity/dashboard/{{ course_id }}/" method="post">
         <select name="list_group" id="list_group">
                 <option value="">--Choose an option--</option>


### PR DESCRIPTION
I did break all dashboard with a `{% if len(groups) > 0 %}` inside the course summary dashboard.

Now the fix is here in branch https://github.com/PremierLangage/premierlangage/tree/fix_dashboard

I did test this branch on a local installation on a single course. It did remove the error server 500. This is no more blind programming but single tested branch. Double check is fine behavior before merging it !!!