### PR TITLE
Second request over logs in csv

### DIFF
--- a/apps/playexo/urls.py
+++ b/apps/playexo/urls.py
@@ -8,4 +8,5 @@ app_name = 'playexo'
 urlpatterns = [
     path(r'test_pl/<int:pl_id>/', views.test_pl, name="test_pl"),
     path(r'download_answers/', views.download_answers, name="download_answers"),
+    path(r'download_answers_csv/', views.download_answers_csv, name="download_answers_csv"),
 ]


### PR DESCRIPTION
Je suis un enfant de Django et je n'arrive pas à comprendre pourquoi cette nouvelle requête fonctionne...

* J'ai tout pris sur : https://docs.djangoproject.com/en/3.1/howto/outputting-csv/#streaming-csv-files (BIEN)
* J'ai bazardé tous les select_related (qui normalement optimise....) (???? POURQUOI ÇA MARCHE TOUJOURS ????)
* Je n'autorise que la sélection sur intervalle fermé (range selection) (BIEN, PLUS DE CONTRÔLE)
* J'ai épuré à mort la requête originelle (BIEN, MOINS DE COMPLEXITÉ)

J'ai testé localement sur une toute petite bdd d'answer (99 logs sur mon PC personnel), je n'ai pas réussi à trouver d'incohérence comme la requête originale qui est déployée sur pl.u-pem.

C'est pas très propre mais malheureusement, il faudrait déployer et tester à grande échelle pour savoir si ça marche ou pas (99 logs contre 800 000 sur u-pem). C'est moche de déployer un outil dont on n'a pas démontré le bon fonctionnement mais seul les enseignants admin peuvent utiliser la requêtes (un peu moins moche).