### PR TITLE
Remove testez and Télécharger l'environement buttons from demo mode

### DIFF
--- a/apps/playexo/templates/playexo/preview.html
+++ b/apps/playexo/templates/playexo/preview.html
@@ -29,18 +29,22 @@
                     <span class="ion-hide-md-down">Valider</span>
                 </button>
                 {% if tests %}
-                <a type="button" class="btn btn-primary action-test"
-                href="{{ url('playexo:test_pl', pl_id__)}}"
-                target="_blank" test>
-                    <i class="fas fa-angle-double-right"></i>
-                    <span class="ion-hide-md-down">Tester</span>
-                </a>
+		  {% if '/demo/' not in request.path %}
+                  <a type="button" class="btn btn-primary action-test"
+                  href="{{ url('playexo:test_pl', pl_id__)}}"
+                  target="_blank" test>
+                      <i class="fas fa-angle-double-right"></i>
+                      <span class="ion-hide-md-down">Tester</span>
+                  </a>
+		  {% endif %}
                 {% endif %}
+		{% if '/demo/' not in request.path %}
                 <a type="button" class="btn btn-secondary action-download-env"
                 href="{{ url('filebrowser:dlenv', id__) }}" download>
                     <i class="fas fa-download"></i>
                     <span class="ion-hide-md-down">Télécharger l'Environnement</span>
                 </a>
+		{% endif %}
             </div>
         </div>
         <!-- SPINNER -->


### PR DESCRIPTION
So, I did understand that the demo mode (for non looged user) of PLaTon is a small hijack of preview mode (for teacher-editor).

I am not very happy with this fix but this last one is so very simple (it just check if the URL contains /demo/ or not).

This could allow to close #396 before a refactoring with real 'playmode' dispatch. The website and a lot of place will benefit directly from this small fix.