### PR TITLE
Course playboard refine

### DIFF
--- a/apps/activity/activity_type/pltp.py
+++ b/apps/activity/activity_type/pltp.py
@@ -8,6 +8,93 @@ from loader.models import PL
 from playexo.enums import State
 from playexo.models import Answer
 
+from random import randint
+
+def color(p):
+    """Return the adapted color for `p` percent 
+    achievement.
+    """
+    coef = 2.0 - (max([p-50, 50-p]) / 50.0)
+    #coef = 1
+    r = coef*180*(1 - (p/100.0))
+    g = coef*180*(p/100.0)
+    b = 0
+    return (int(r), int(g), int(b))
+
+
+def graph_percent(p):
+    """Return SVG code drawing a small graphical
+    percent.
+    """
+    p = int(p)
+    r,g,b = color(p)
+    ans='<svg height="80" width="80">'
+    ans+='<polygon points="0,0 80,0 80,80 0,80" style="fill:rgb(255,255,255)" />'
+    ans+='<circle cx="40" cy="40" r="40" fill="rgb({},{},{})" />'.format(r, g, b)
+    ans+='<circle cx="40" cy="40" r="30" fill="rgb(255,255,255)" />'
+    # all the following to hide the proper sector part of the circle
+    if p <= 25:
+        ans+='<polygon points="0,0 0,80 40,80 40,0" style="fill:rgb(255,255,255)" />'
+        ans+='<polygon points="40,40 40,80 80,80 80,40" style="fill:rgb(255,255,255)" />'
+        if p < 13:
+            ab = max([int(80 - 40*((12.5 - p)/12.5)), 44])
+            ans+='<polygon points="{},0 40,40 80,40 80,0" style="fill:rgb(255,255,255)" />'.format(ab)
+        else:
+            od = 40*((p-12.5)/12.5)
+            ans+='<polygon points="80,{} 40,40 80,40" style="fill:rgb(255,255,255)" />'.format(od)
+    elif p <= 50:
+        ans+='<polygon points="0,0 0,80 40,80 40,0" style="fill:rgb(255,255,255)" />'
+        if p < 38:
+            od = 80-40*((37.5-p)/12.5) 
+            ans+='<polygon points="40,40 40,80 80,80 80, {}" style="fill:rgb(255,255,255)" />'.format(od)
+        else:
+            ab = 40+40*((50-p)/12.5)
+            ans+='<polygon points="40,40 40,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
+    elif p <= 75:
+        ans+='<polygon points="0,0 0,40 40,40 40,0" style="fill:rgb(255,255,255)" />'
+        if p < 63:
+            ab = 40*((62.5-p)/12.5)
+            ans+='<polygon points="40,40 0,40 0,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
+        else:
+            od = 40+40*((75-p)/12.5)
+            ans+='<polygon points="40,40 0,40 0,{}" style="fill:rgb(255,255,255)" />'.format(od)
+    else:
+        if p < 88:
+            od = 40*((87.5-p)/12.5)
+            ans+='<polygon points="0,0 0,{} 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(od)
+        else:
+            ab = 40 - 40*((100-p)/12.5)
+            ans+='<polygon points="{},0 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(ab)
+    # To try to center the text correctly
+    if p <= 9:
+        ans+='<text x="24" y="46" font-size="20" fill="black">{}%</text>'.format(p)
+    elif p <= 99:
+        ans+='<text x="19" y="46" font-size="20" fill="black">{}%</text>'.format(p)
+    else:
+        ans+='<text x="12" y="46" font-size="20" fill="black">100%</text>'
+    ans+='</svg>'
+    return ans
+
+def user_progression(user, activity):
+    """Return a tuple of two integers `(progression, average)` where
+    `progression` is the percent of work done and `average` is the
+    percent of quality(grades) over touched exercices.
+    """
+    pl = activity.pl.all()
+    nb_pl_touched=0
+    nb_pl_graded=0
+    sum_grades=0
+        
+    for i in pl:
+        answer = Answer.highest_grade(i, user)
+        if answer is not None:
+            nb_pl_touched += 1
+            if answer.grade is not None:
+                nb_pl_graded += 1
+                sum_grades += answer.grade
+    progr = (100*nb_pl_graded + 10*nb_pl_touched) / len(pl) if len(pl) else 0 # 10% for readed exercices
+    average = sum_grades / nb_pl_graded if nb_pl_graded else 0 # average highest grades over graded only exos
+    return (progr, average)
 
 
 class Pltp(AbstractActivityType):
@@ -65,13 +152,18 @@ class Pltp(AbstractActivityType):
             }
             for elem in activity.indexed_pl()
         ]
-        
+
+        # user_progression(request.user, activity)
+
         return get_template("activity/activity_type/pltp/small.html").render({
             'title':      activity.activity_data['title'],
             'pl':         pl,
             'id':         activity.id,
             'open':       activity.open,
-            'instructor': request.user in activity.teacher.all()
+            'instructor': request.user in activity.teacher.all(),
+            'nb_exos':    len(pl),
+            'progr':      graph_percent(randint(0, 100)),
+            'quality':    graph_percent(randint(0, 100)),
         }, request)
     
     
@@ -256,3 +348,24 @@ class Pltp(AbstractActivityType):
         response = HttpResponse(csv, content_type="text/csv")
         response['Content-Disposition'] = 'attachment;filename=notes.csv'
         return response
+
+    def user_progression(self, user, activity):
+        """Return a tuple of two integers `(progression, average)` where
+        `progression` is the percent of work done and `average` is the
+        percent of quality(grades) over touched exercices.
+        """
+        pl = activity.pl.all()
+        nb_pl_touched=0
+        nb_pl_graded=0
+        sum_grades=0
+        
+        for i in pl:
+            answer = Answer.highest_grade(i, user)
+            if answer is not None:
+                nb_pl_touched += 1
+                if answer.grade is not None:
+                    nb_pl_graded += 1
+                    sum_grades += answer.grade
+        progr = (100*nb_pl_graded + 10*nb_pl_touched) / len(pl) # 10% for readed exercices
+        average = sum_grades / nb_pl_graded # average highest grades over graded only exos
+        return (progr, average)

--- a/apps/activity/activity_type/pltp.py
+++ b/apps/activity/activity_type/pltp.py
@@ -289,7 +289,6 @@ def user_progression(user, activity):
             if answer.grade is not None:
                 nb_pl_graded += 1
                 sum_grades += answer.grade
-    progr = (100*nb_pl_graded + 10*(nb_pl_touched - nb_pl_graded)) / len(pl) if len(pl) else 0
+    progr = (100*nb_pl_graded + 10*(nb_pl_touched - nb_pl_graded)) / len(pl) if pl else 0
     average = sum_grades / nb_pl_graded if nb_pl_graded else 0
     return (progr, average)
-

--- a/apps/activity/activity_type/pltp.py
+++ b/apps/activity/activity_type/pltp.py
@@ -10,92 +10,6 @@ from playexo.models import Answer
 
 from random import randint
 
-def color(p):
-    """Return the adapted color for `p` percent 
-    achievement.
-    """
-    coef = 2.0 - (max([p-50, 50-p]) / 50.0)
-    #coef = 1
-    r = coef*180*(1 - (p/100.0))
-    g = coef*180*(p/100.0)
-    b = 0
-    return (int(r), int(g), int(b))
-
-
-def graph_percent(p):
-    """Return SVG code drawing a small graphical
-    percent.
-    """
-    p = int(p)
-    r,g,b = color(p)
-    ans='<svg height="80" width="80">'
-    ans+='<polygon points="0,0 80,0 80,80 0,80" style="fill:rgb(255,255,255)" />'
-    ans+='<circle cx="40" cy="40" r="40" fill="rgb({},{},{})" />'.format(r, g, b)
-    ans+='<circle cx="40" cy="40" r="30" fill="rgb(255,255,255)" />'
-    # all the following to hide the proper sector part of the circle
-    if p <= 25:
-        ans+='<polygon points="0,0 0,80 40,80 40,0" style="fill:rgb(255,255,255)" />'
-        ans+='<polygon points="40,40 40,80 80,80 80,40" style="fill:rgb(255,255,255)" />'
-        if p < 13:
-            ab = max([int(80 - 40*((12.5 - p)/12.5)), 44])
-            ans+='<polygon points="{},0 40,40 80,40 80,0" style="fill:rgb(255,255,255)" />'.format(ab)
-        else:
-            od = 40*((p-12.5)/12.5)
-            ans+='<polygon points="80,{} 40,40 80,40" style="fill:rgb(255,255,255)" />'.format(od)
-    elif p <= 50:
-        ans+='<polygon points="0,0 0,80 40,80 40,0" style="fill:rgb(255,255,255)" />'
-        if p < 38:
-            od = 80-40*((37.5-p)/12.5) 
-            ans+='<polygon points="40,40 40,80 80,80 80, {}" style="fill:rgb(255,255,255)" />'.format(od)
-        else:
-            ab = 40+40*((50-p)/12.5)
-            ans+='<polygon points="40,40 40,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
-    elif p <= 75:
-        ans+='<polygon points="0,0 0,40 40,40 40,0" style="fill:rgb(255,255,255)" />'
-        if p < 63:
-            ab = 40*((62.5-p)/12.5)
-            ans+='<polygon points="40,40 0,40 0,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
-        else:
-            od = 40+40*((75-p)/12.5)
-            ans+='<polygon points="40,40 0,40 0,{}" style="fill:rgb(255,255,255)" />'.format(od)
-    else:
-        if p < 88:
-            od = 40*((87.5-p)/12.5)
-            ans+='<polygon points="0,0 0,{} 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(od)
-        else:
-            ab = 40 - 40*((100-p)/12.5)
-            ans+='<polygon points="{},0 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(ab)
-    # To try to center the text correctly
-    if p <= 9:
-        ans+='<text x="24" y="46" font-size="20" fill="black">{}%</text>'.format(p)
-    elif p <= 99:
-        ans+='<text x="19" y="46" font-size="20" fill="black">{}%</text>'.format(p)
-    else:
-        ans+='<text x="12" y="46" font-size="20" fill="black">100%</text>'
-    ans+='</svg>'
-    return ans
-
-def user_progression(user, activity):
-    """Return a tuple of two integers `(progression, average)` where
-    `progression` is the percent of work done and `average` is the
-    percent of quality(grades) over touched exercices.
-    """
-    pl = activity.pl.all()
-    nb_pl_touched=0
-    nb_pl_graded=0
-    sum_grades=0
-        
-    for i in pl:
-        answer = Answer.highest_grade(i, user)
-        if answer is not None:
-            nb_pl_touched += 1
-            if answer.grade is not None:
-                nb_pl_graded += 1
-                sum_grades += answer.grade
-    progr = (100*nb_pl_graded + 10*nb_pl_touched) / len(pl) if len(pl) else 0 # 10% for readed exercices
-    average = sum_grades / nb_pl_graded if nb_pl_graded else 0 # average highest grades over graded only exos
-    return (progr, average)
-
 
 class Pltp(AbstractActivityType):
     
@@ -153,7 +67,7 @@ class Pltp(AbstractActivityType):
             for elem in activity.indexed_pl()
         ]
 
-        # progr, quality = user_progression(request.user, activity)
+        progr, quality = user_progression(request.user, activity)
 
         return get_template("activity/activity_type/pltp/small.html").render({
             'title':      activity.activity_data['title'],
@@ -162,8 +76,8 @@ class Pltp(AbstractActivityType):
             'open':       activity.open,
             'instructor': request.user in activity.teacher.all(),
             'nb_exos':    len(pl),
-            'progr':      graph_percent(randint(0, 100)),
-            'quality':    graph_percent(randint(0, 100)),
+            'progr':      graph_percent(progr),
+            'quality':    graph_percent(quality),
         }, request)
     
     
@@ -349,23 +263,88 @@ class Pltp(AbstractActivityType):
         response['Content-Disposition'] = 'attachment;filename=notes.csv'
         return response
 
-    def user_progression(self, user, activity):
-        """Return a tuple of two integers `(progression, average)` where
-        `progression` is the percent of work done and `average` is the
-        percent of quality(grades) over touched exercices.
-        """
-        pl = activity.pl.all()
-        nb_pl_touched=0
-        nb_pl_graded=0
-        sum_grades=0
+
+def user_progression(user, activity):
+    """Return a tuple of two integers `(progression, average)` where
+    `progression` is the percent of work done and `average` is the
+    percent of quality(grades) over touched exercices.
+    """
+    pl = activity.pl.all()
+    nb_pl_touched=0
+    nb_pl_graded=0
+    sum_grades=0
         
-        for i in pl:
-            answer = Answer.highest_grade(i, user)
-            if answer is not None:
-                nb_pl_touched += 1
-                if answer.grade is not None:
-                    nb_pl_graded += 1
-                    sum_grades += answer.grade
-        progr = (100*nb_pl_graded + 10*nb_pl_touched) / len(pl) # 10% for readed exercices
-        average = sum_grades / nb_pl_graded # average highest grades over graded only exos
-        return (progr, average)
+    for i in pl:
+        answer = Answer.highest_grade(i, user)
+        if answer is not None:
+            nb_pl_touched += 1
+            if answer.grade is not None:
+                nb_pl_graded += 1
+                sum_grades += answer.grade
+    progr = (100*nb_pl_graded + 10*nb_pl_touched) / len(pl) if len(pl) else 0 # 10% for readed exercices
+    average = sum_grades / nb_pl_graded if nb_pl_graded else 0 # average highest grades over graded only exos
+    return (progr, average)
+
+def color(p):
+    """Return the adapted color for `p` percent 
+    achievement.
+    """
+    coef = 2.0 - (max([p-50, 50-p]) / 50.0)
+    #coef = 1
+    r = coef*180*(1 - (p/100.0))
+    g = coef*180*(p/100.0)
+    b = 0
+    return (int(r), int(g), int(b))
+
+def graph_percent(p):
+    """Return SVG code drawing a small graphical
+    percent.
+    """
+    p = int(p)
+    r,g,b = color(p)
+    ans='<svg height="80" width="80">'
+    ans+='<polygon points="0,0 80,0 80,80 0,80" style="fill:rgb(255,255,255)" />'
+    ans+='<circle cx="40" cy="40" r="40" fill="rgb({},{},{})" />'.format(r, g, b)
+    ans+='<circle cx="40" cy="40" r="30" fill="rgb(255,255,255)" />'
+    # all the following to hide the proper sector part of the circle
+    if p <= 25:
+        ans+='<polygon points="0,0 0,80 40,80 40,0" style="fill:rgb(255,255,255)" />'
+        ans+='<polygon points="40,40 40,80 80,80 80,40" style="fill:rgb(255,255,255)" />'
+        if p < 13:
+            ab = max([int(80 - 40*((12.5 - p)/12.5)), 44])
+            ans+='<polygon points="{},0 40,40 80,40 80,0" style="fill:rgb(255,255,255)" />'.format(ab)
+        else:
+            od = 40*((p-12.5)/12.5)
+            ans+='<polygon points="80,{} 40,40 80,40" style="fill:rgb(255,255,255)" />'.format(od)
+    elif p <= 50:
+        ans+='<polygon points="0,0 0,80 40,80 40,0" style="fill:rgb(255,255,255)" />'
+        if p < 38:
+            od = 80-40*((37.5-p)/12.5) 
+            ans+='<polygon points="40,40 40,80 80,80 80, {}" style="fill:rgb(255,255,255)" />'.format(od)
+        else:
+            ab = 40+40*((50-p)/12.5)
+            ans+='<polygon points="40,40 40,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
+    elif p <= 75:
+        ans+='<polygon points="0,0 0,40 40,40 40,0" style="fill:rgb(255,255,255)" />'
+        if p < 63:
+            ab = 40*((62.5-p)/12.5)
+            ans+='<polygon points="40,40 0,40 0,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
+        else:
+            od = 40+40*((75-p)/12.5)
+            ans+='<polygon points="40,40 0,40 0,{}" style="fill:rgb(255,255,255)" />'.format(od)
+    else:
+        if p < 88:
+            od = 40*((87.5-p)/12.5)
+            ans+='<polygon points="0,0 0,{} 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(od)
+        else:
+            ab = 40 - 40*((100-p)/12.5)
+            ans+='<polygon points="{},0 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(ab)
+    # To try to center the text correctly
+    if p <= 9:
+        ans+='<text x="24" y="46" font-size="20" fill="black">{}%</text>'.format(p)
+    elif p <= 99:
+        ans+='<text x="19" y="46" font-size="20" fill="black">{}%</text>'.format(p)
+    else:
+        ans+='<text x="12" y="46" font-size="20" fill="black">100%</text>'
+    ans+='</svg>'
+    return ans

--- a/apps/activity/activity_type/pltp.py
+++ b/apps/activity/activity_type/pltp.py
@@ -10,6 +10,7 @@ from playexo.models import Answer
 
 from shared.graphic_utils import graph_percent
 
+
 class Pltp(AbstractActivityType):
 
 

--- a/apps/activity/activity_type/pltp.py
+++ b/apps/activity/activity_type/pltp.py
@@ -153,7 +153,7 @@ class Pltp(AbstractActivityType):
             for elem in activity.indexed_pl()
         ]
 
-        # user_progression(request.user, activity)
+        # progr, quality = user_progression(request.user, activity)
 
         return get_template("activity/activity_type/pltp/small.html").render({
             'title':      activity.activity_data['title'],

--- a/apps/activity/activity_type/pltp.py
+++ b/apps/activity/activity_type/pltp.py
@@ -11,7 +11,8 @@ from playexo.models import Answer
 from shared.graphic_utils import graph_percent
 
 class Pltp(AbstractActivityType):
-    
+
+
     def student_dashboard(self, request, activity, session):
         """
         This method is called when the dashboard of an activity is requested for a student.
@@ -278,9 +279,9 @@ def user_progression(user, activity):
     exercices. Quality is zero if no exercice has been graded.
     """
     pl = activity.pl.all()
-    nb_pl_touched=0
-    nb_pl_graded=0
-    sum_grades=0
+    nb_pl_touched = 0
+    nb_pl_graded = 0
+    sum_grades = 0
         
     for i in pl:
         answer = Answer.highest_grade(i, user)

--- a/apps/activity/templates/activity/activity_type/pltp/small.html
+++ b/apps/activity/templates/activity/activity_type/pltp/small.html
@@ -1,6 +1,5 @@
 <ion-card>
   <!-- <ion-img src="{{ static('activity/images/pltp.png') }}" width="10%"></ion-img> -->
-  <!-- <img src="{{ static('activity/images/pltp.png') }}" width="10%"> -->
   <table>
     <tr>
       <td width="50%"><img src="{{ static('activity/images/pltp.png') }}" ></td>
@@ -15,7 +14,7 @@
     </tr>
     <tr>
       <td align="center"><b>Avancement<br>sur les exos</b></td>
-      <td align="center"><b>Moyenne des<br>exos traités</b></td>
+      <td align="center"><b>Réussite sur<br>exos traités</b></td>
     </tr>
     <tr>
       <td align="center">{{ progr|safe }}</td><td align="center">{{ quality|safe }}</td>

--- a/apps/activity/templates/activity/activity_type/pltp/small.html
+++ b/apps/activity/templates/activity/activity_type/pltp/small.html
@@ -1,8 +1,27 @@
 <ion-card>
-    <ion-img src="{{ static('activity/images/pltp.png') }}"></ion-img>
-    <ion-card-header>
-        <ion-card-title>{{ title }}</ion-card-title>
-    </ion-card-header>
+  <!-- <ion-img src="{{ static('activity/images/pltp.png') }}" width="10%"></ion-img> -->
+  <!-- <img src="{{ static('activity/images/pltp.png') }}" width="10%"> -->
+  <table>
+    <tr>
+      <td width="50%"><img src="{{ static('activity/images/pltp.png') }}" ></td>
+      <td width="50%" align="center" style="vertical-align:middle; font-size:1.5em"><b>Fiche de <br>{{ nb_exos }} exercices</b></td>
+    </tr>
+    <tr>
+      <td colspan="2">
+	<ion-card-header>
+          <ion-card-title>{{ title }}</ion-card-title>
+	</ion-card-header>
+      </td>
+    </tr>
+    <tr>
+      <td align="center"><b>Avancement<br>sur les exos</b></td>
+      <td align="center"><b>Moyenne des<br>exos traités</b></td>
+    </tr>
+    <tr>
+      <td align="center">{{ progr|safe }}</td><td align="center">{{ quality|safe }}</td>
+    </tr>
+  </table>
+    
     <ion-card-content>
         <ion-buttons slot="start">
             <ion-button href="{{ url('activity:play', id) }}" data-toggle="tooltip" data-placement="top" title="Lancer">

--- a/apps/shared/graphic_utils.py
+++ b/apps/shared/graphic_utils.py
@@ -1,0 +1,95 @@
+"""
+This file gather some graphical utilities that could be used inside
+other apps of the projet PLaTon.
+
+N. Borie(poor graphical programmer) : original version 10. jan 2021.
+Feel free to modify, throw away or use better technology.
+
+TESTS:
+
+>>> all([graph_percent(i) for i in range(101)])
+True
+"""
+
+def color_percent(p):
+    """Return the adapted color for `p` percent achievement.  `0`
+    percent will be dark red, `100` percent will be dark gren. A
+    linear interpolation is returned beetween these extrema but a
+    coefficient increases the luminosity around the midle `50`.
+
+    TESTS:
+
+    >>> color_percent(0)
+    (180, 0, 0)
+    >>> color_percent(50)
+    (180, 180, 0)
+    >>> color_percent(83)
+    (41, 200, 0)
+    >>> color_percent(100)
+    (0, 180, 0)
+    """
+    coef = 2.0 - (max([p-50, 50-p]) / 50.0)
+    #coef = 1
+    r = coef*180*(1 - (p/100.0))
+    g = coef*180*(p/100.0)
+    b = 0
+    return (int(r), int(g), int(b))
+
+def graph_percent(p):
+    """Return a python string which is an SVG code drawing a angular
+    portion of circle around a text showing the percent `p`. The color
+    of circles part use function `color_percent`.
+
+    TESTS:
+
+    >>> len(graph_percent(53)) > 0
+    True
+    """
+    p = int(p)
+    r,g,b = color_percent(p)
+    ans='<svg height="80" width="80">'
+    ans+='<polygon points="0,0 80,0 80,80 0,80" style="fill:rgb(255,255,255)" />'
+    ans+='<circle cx="40" cy="40" r="40" fill="rgb({},{},{})" />'.format(r, g, b)
+    ans+='<circle cx="40" cy="40" r="30" fill="rgb(255,255,255)" />'
+    # all the following to hide the proper sector part of the circle
+    if p <= 25:
+        ans+='<polygon points="0,0 0,80 40,80 40,0" style="fill:rgb(255,255,255)" />'
+        ans+='<polygon points="40,40 40,80 80,80 80,40" style="fill:rgb(255,255,255)" />'
+        if p < 13:
+            ab = max([int(80 - 40*((12.5 - p)/12.5)), 44])
+            ans+='<polygon points="{},0 40,40 80,40 80,0" style="fill:rgb(255,255,255)" />'.format(ab)
+        else:
+            od = 40*((p-12.5)/12.5)
+            ans+='<polygon points="80,{} 40,40 80,40" style="fill:rgb(255,255,255)" />'.format(od)
+    elif p <= 50:
+        ans+='<polygon points="0,0 0,80 40,80 40,0" style="fill:rgb(255,255,255)" />'
+        if p < 38:
+            od = 80-40*((37.5-p)/12.5) 
+            ans+='<polygon points="40,40 40,80 80,80 80, {}" style="fill:rgb(255,255,255)" />'.format(od)
+        else:
+            ab = 40+40*((50-p)/12.5)
+            ans+='<polygon points="40,40 40,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
+    elif p <= 75:
+        ans+='<polygon points="0,0 0,40 40,40 40,0" style="fill:rgb(255,255,255)" />'
+        if p < 63:
+            ab = 40*((62.5-p)/12.5)
+            ans+='<polygon points="40,40 0,40 0,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
+        else:
+            od = 40+40*((75-p)/12.5)
+            ans+='<polygon points="40,40 0,40 0,{}" style="fill:rgb(255,255,255)" />'.format(od)
+    else:
+        if p < 88:
+            od = 40*((87.5-p)/12.5)
+            ans+='<polygon points="0,0 0,{} 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(od)
+        else:
+            ab = 40 - 40*((100-p)/12.5)
+            ans+='<polygon points="{},0 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(ab)
+    # To center the text (nice display on firefox, bad centered on chrome-like)
+    if p <= 9:
+        ans+='<text x="24" y="46" font-size="20" fill="black">{}%</text>'.format(p)
+    elif p <= 99:
+        ans+='<text x="19" y="46" font-size="20" fill="black">{}%</text>'.format(p)
+    else:
+        ans+='<text x="12" y="46" font-size="20" fill="black">100%</text>'
+    ans+='</svg>'
+    return ans

--- a/apps/shared/graphic_utils.py
+++ b/apps/shared/graphic_utils.py
@@ -58,34 +58,42 @@ def graph_percent(p):
         ans += '<polygon points="0,0 0,80 40,80 40,0" style="fill:rgb(255,255,255)" />'
         ans += '<polygon points="40,40 40,80 80,80 80,40" style="fill:rgb(255,255,255)" />'
         if p < 13:
-            ab = max([int(80 - 40*((12.5 - p)/12.5)), 44])
-            ans += '<polygon points="{},0 40,40 80,40 80,0" style="fill:rgb(255,255,255)" />'.format(ab)
+            ab = max([int(80 - 40 * ((12.5 - p)/12.5)), 44])
+            ans += '<polygon points="'
+            ans += '{},0 40,40 80,40 80,0" style="fill:rgb(255,255,255)" />'.format(ab)
         else:
-            od = 40*((p-12.5)/12.5)
-            ans += '<polygon points="80,{} 40,40 80,40" style="fill:rgb(255,255,255)" />'.format(od)
+            od = 40 * ((p-12.5)/12.5)
+            ans += '<polygon points="'
+            ans += '80,{} 40,40 80,40" style="fill:rgb(255,255,255)" />'.format(od)
     elif p <= 50:
         ans += '<polygon points="0,0 0,80 40,80 40,0" style="fill:rgb(255,255,255)" />'
         if p < 38:
-            od = 80-40*((37.5-p)/12.5) 
-            ans +='<polygon points="40,40 40,80 80,80 80, {}" style="fill:rgb(255,255,255)" />'.format(od)
+            od = 80 - 40*((37.5-p)/12.5)
+            ans += '<polygon points="'
+            ans += '40,40 40,80 80,80 80, {}" style="fill:rgb(255,255,255)" />'.format(od)
         else:
-            ab = 40+40*((50-p)/12.5)
-            ans += '<polygon points="40,40 40,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
+            ab = 40 + 40*((50-p)/12.5)
+            ans += '<polygon points="'
+            ans += '40,40 40,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
     elif p <= 75:
-        ans+='<polygon points="0,0 0,40 40,40 40,0" style="fill:rgb(255,255,255)" />'
+        ans += '<polygon points="0,0 0,40 40,40 40,0" style="fill:rgb(255,255,255)" />'
         if p < 63:
-            ab = 40*((62.5-p)/12.5)
-            ans += '<polygon points="40,40 0,40 0,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
+            ab = 40 * ((62.5-p)/12.5)
+            ans += '<polygon points="'
+            ans += '40,40 0,40 0,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
         else:
-            od = 40+40*((75-p)/12.5)
-            ans += '<polygon points="40,40 0,40 0,{}" style="fill:rgb(255,255,255)" />'.format(od)
+            od = 40 + 40*((75-p)/12.5)
+            ans += '<polygon points="'
+            ans += '40,40 0,40 0,{}" style="fill:rgb(255,255,255)" />'.format(od)
     else:
         if p < 88:
-            od = 40*((87.5-p)/12.5)
-            ans += '<polygon points="0,0 0,{} 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(od)
+            od = 40 * ((87.5-p)/12.5)
+            ans += '<polygon points="'
+            ans += '0,0 0,{} 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(od)
         else:
             ab = 40 - 40*((100-p)/12.5)
-            ans += '<polygon points="{},0 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(ab)
+            ans += '<polygon points="'
+            ans += '{},0 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(ab)
     # To center the text (nice display on firefox, bad centered on chrome-like)
     if p <= 9:
         ans += '<text x="24" y="46" font-size="20" fill="black">{}%</text>'.format(p)

--- a/apps/shared/graphic_utils.py
+++ b/apps/shared/graphic_utils.py
@@ -11,6 +11,7 @@ TESTS:
 True
 """
 
+
 def color_percent(p):
     """Return the adapted color for `p` percent achievement.  `0`
     percent will be dark red, `100` percent will be dark gren. A
@@ -29,11 +30,12 @@ def color_percent(p):
     (0, 180, 0)
     """
     coef = 2.0 - (max([p-50, 50-p]) / 50.0)
-    #coef = 1
+    # coef = 1
     r = coef*180*(1 - (p/100.0))
     g = coef*180*(p/100.0)
     b = 0
     return (int(r), int(g), int(b))
+
 
 def graph_percent(p):
     """Return a python string which is an SVG code drawing a angular
@@ -46,50 +48,50 @@ def graph_percent(p):
     True
     """
     p = int(p)
-    r,g,b = color_percent(p)
-    ans='<svg height="80" width="80">'
-    ans+='<polygon points="0,0 80,0 80,80 0,80" style="fill:rgb(255,255,255)" />'
-    ans+='<circle cx="40" cy="40" r="40" fill="rgb({},{},{})" />'.format(r, g, b)
-    ans+='<circle cx="40" cy="40" r="30" fill="rgb(255,255,255)" />'
+    r, g, b = color_percent(p)
+    ans = '<svg height="80" width="80">'
+    ans += '<polygon points="0,0 80,0 80,80 0,80" style="fill:rgb(255,255,255)" />'
+    ans += '<circle cx="40" cy="40" r="40" fill="rgb({},{},{})" />'.format(r, g, b)
+    ans += '<circle cx="40" cy="40" r="30" fill="rgb(255,255,255)" />'
     # all the following to hide the proper sector part of the circle
     if p <= 25:
-        ans+='<polygon points="0,0 0,80 40,80 40,0" style="fill:rgb(255,255,255)" />'
-        ans+='<polygon points="40,40 40,80 80,80 80,40" style="fill:rgb(255,255,255)" />'
+        ans += '<polygon points="0,0 0,80 40,80 40,0" style="fill:rgb(255,255,255)" />'
+        ans += '<polygon points="40,40 40,80 80,80 80,40" style="fill:rgb(255,255,255)" />'
         if p < 13:
             ab = max([int(80 - 40*((12.5 - p)/12.5)), 44])
-            ans+='<polygon points="{},0 40,40 80,40 80,0" style="fill:rgb(255,255,255)" />'.format(ab)
+            ans += '<polygon points="{},0 40,40 80,40 80,0" style="fill:rgb(255,255,255)" />'.format(ab)
         else:
             od = 40*((p-12.5)/12.5)
-            ans+='<polygon points="80,{} 40,40 80,40" style="fill:rgb(255,255,255)" />'.format(od)
+            ans += '<polygon points="80,{} 40,40 80,40" style="fill:rgb(255,255,255)" />'.format(od)
     elif p <= 50:
-        ans+='<polygon points="0,0 0,80 40,80 40,0" style="fill:rgb(255,255,255)" />'
+        ans += '<polygon points="0,0 0,80 40,80 40,0" style="fill:rgb(255,255,255)" />'
         if p < 38:
             od = 80-40*((37.5-p)/12.5) 
-            ans+='<polygon points="40,40 40,80 80,80 80, {}" style="fill:rgb(255,255,255)" />'.format(od)
+            ans +='<polygon points="40,40 40,80 80,80 80, {}" style="fill:rgb(255,255,255)" />'.format(od)
         else:
             ab = 40+40*((50-p)/12.5)
-            ans+='<polygon points="40,40 40,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
+            ans += '<polygon points="40,40 40,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
     elif p <= 75:
         ans+='<polygon points="0,0 0,40 40,40 40,0" style="fill:rgb(255,255,255)" />'
         if p < 63:
             ab = 40*((62.5-p)/12.5)
-            ans+='<polygon points="40,40 0,40 0,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
+            ans += '<polygon points="40,40 0,40 0,80 {},80" style="fill:rgb(255,255,255)" />'.format(ab)
         else:
             od = 40+40*((75-p)/12.5)
-            ans+='<polygon points="40,40 0,40 0,{}" style="fill:rgb(255,255,255)" />'.format(od)
+            ans += '<polygon points="40,40 0,40 0,{}" style="fill:rgb(255,255,255)" />'.format(od)
     else:
         if p < 88:
             od = 40*((87.5-p)/12.5)
-            ans+='<polygon points="0,0 0,{} 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(od)
+            ans += '<polygon points="0,0 0,{} 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(od)
         else:
             ab = 40 - 40*((100-p)/12.5)
-            ans+='<polygon points="{},0 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(ab)
+            ans += '<polygon points="{},0 40,40 40,0" style="fill:rgb(255,255,255)" />'.format(ab)
     # To center the text (nice display on firefox, bad centered on chrome-like)
     if p <= 9:
-        ans+='<text x="24" y="46" font-size="20" fill="black">{}%</text>'.format(p)
+        ans += '<text x="24" y="46" font-size="20" fill="black">{}%</text>'.format(p)
     elif p <= 99:
-        ans+='<text x="19" y="46" font-size="20" fill="black">{}%</text>'.format(p)
+        ans += '<text x="19" y="46" font-size="20" fill="black">{}%</text>'.format(p)
     else:
-        ans+='<text x="12" y="46" font-size="20" fill="black">100%</text>'
-    ans+='</svg>'
+        ans += '<text x="12" y="46" font-size="20" fill="black">100%</text>'
+    ans += '</svg>'
     return ans


### PR DESCRIPTION
This is a proposition to mainly increase the student experience on PLaTon...

When you have something like 4 courses and 10 PLTP for each courses, it is difficult to see what have been done and what remains to be done. The goal of this branch is increase the information on the `small` view of PLTP (which are integrated inside the `play` view of courses).

Here is screenshot done on a local installation.

The Student's rendering...
![view_student](https://user-images.githubusercontent.com/6042616/104119106-bded2080-532d-11eb-831b-262b8aba3920.png)

The teacher's rendering... (it is the same view just the controls are enable on PLTP....)
![view_teacher](https://user-images.githubusercontent.com/6042616/104119110-c34a6b00-532d-11eb-98d5-e85c87d1d51c.png)

ANYWAY, I THINK THIS BRANCH CAN BE DANGEROUS !!!!
* I did test it on my personnal computer with data indépendant from real PLaTon which is good !!!
* My local bdd has 238 items answers WHICH IS VERY VERY BAD !!! 

PLEASE TEST IT ON A PL-TEST OR SOMETHING EQUIVALENT WITH 800 000 ITEMS IN ANSWERS. IF THIS BRANCH MAKES TERRIBLY SLOW ALL EXERCICES ACCESS, IT COULD BE TERRIBLE, STUDENT WILL LEAVE THE PLATEFORM. SPEED TESTS HAVE TO BE PERFORMED BEFORE SETTING ANY POSITIVE REVIEW ! IF THIS NOT SLOW THE PLAY VIEW OF COURSE, I WILL BE OK IMHO...