### PR TITLE
Two fix from preprod observations

### DIFF
--- a/apps/activity/activity_type/pltp.py
+++ b/apps/activity/activity_type/pltp.py
@@ -43,7 +43,8 @@ class Pltp(AbstractActivityType):
                     'name':  pl.json['title'],
                     'state': state
                 })
-                exos[count][state] += 1
+                if state != State.ERROR:
+                    exos[count][state] += 1
                 if ans_grade and ans_grade.grade is not None:
                     exos[count]['sum_grades'] += ans_grade.grade
             student.append({

--- a/apps/activity/templates/activity/activity_type/pltp/teacher_dashboard.html
+++ b/apps/activity/templates/activity/activity_type/pltp/teacher_dashboard.html
@@ -63,11 +63,11 @@
                 <tbody>
                     {% for dico_exo in exos %}
                     <tr>
-		        {% for key, val in dico_exo.items() %}
-                        <td>
-                            <center>{{ val }}</center>
-                        </td>
-			{% endfor %}
+		      <td>{{ dico_exo['name'] }}</td>
+		      {% for item in state %}
+		        <td>{{ dico_exo[item] }}</td>
+		      {% endfor %}
+		      <td>{{ "%.2f"|format(dico_exo['mean']|float) }}</td>
                     </tr>
                     {% endfor %}
                     <tr>


### PR DESCRIPTION
This small commit fix two bad things seens on preprod :

* The average note by exos on PLTP student dashboard now print at most 2 décimals after comma
* If the PLTP contains Error State for some student, it should no more break the dashboard