### PR TITLE
better student summary + enable student view

### DIFF
--- a/apps/activity/activity_type/course.py
+++ b/apps/activity/activity_type/course.py
@@ -288,7 +288,7 @@ class Course(AbstractActivityType):
 
     def student_summary(self, student_id, request, activity):
         """
-        This is a the dashboard of a whole course but focus on a student whose 
+        This is a the dashboard of a whole course but focus on a student whose
         id is `student_id`.
         """
         try:

--- a/apps/activity/activity_type/course.py
+++ b/apps/activity/activity_type/course.py
@@ -309,6 +309,7 @@ class Course(AbstractActivityType):
         for t in teacher_list:
             if t in student_list:
                 student_list.remove(t)
+        nb_student = len(student_list) if student_list else 1
         tp = list()
         for a in activities:
             question = list()
@@ -333,13 +334,13 @@ class Course(AbstractActivityType):
                     'name': pl.json['title'],
                     'all_mark': all_mark,
                     'mark': mark_student,
-                    'mean': sum(all_mark) / len(all_mark),
+                    'mean': sum(all_mark) / nb_student,
                     'min': min(all_mark),
                     'max': max(all_mark),
                 })
-            len_tp = len(question) if len(question) else 1
+            len_tp = len(question) if question else 1
             all_grouped_mark = list()
-            for i in range(len(student_list)):
+            for i in range(nb_student):
                 all_grouped_mark.append(sum([q['all_mark'][i] for q in question]) / len_tp)
             tp.append({
                 'name': a.activity_data['title'],
@@ -349,14 +350,14 @@ class Course(AbstractActivityType):
                 'pl': question,
                 'all_mark': all_grouped_mark,
                 'mark': sum([q['mark'] for q in question]) / len_tp,
-                'mean': sum(all_grouped_mark) / len(student_list),
+                'mean': sum(all_grouped_mark) / nb_student,
                 'min': min(all_grouped_mark),
                 'max': max(all_grouped_mark),
             })
 
-        len_act = len(tp) if len(tp) else 1
+        len_act = len(tp) if tp else 1
         all_act_mark = list()
-        for i in range(len(student_list)):
+        for i in range(nb_student):
             all_act_mark.append(sum([a['all_mark'][i] for a in tp]) / len_act)
         course_mark = sum([a['mark'] for a in tp]) / len_act
         return render(request, 'activity/activity_type/course/student_summary.html', {
@@ -366,7 +367,7 @@ class Course(AbstractActivityType):
             'activities': tp,
             'course_id': activity.id,
             'mark': course_mark,
-            'mean': sum(all_act_mark) / len(student_list),
+            'mean': sum(all_act_mark) / nb_student,
             'min': min(all_act_mark),
             'max': max(all_act_mark),
             'nb_more': sum([1 for m in all_act_mark if m > course_mark]),

--- a/apps/activity/templates/activity/activity_type/course/index.html
+++ b/apps/activity/templates/activity/activity_type/course/index.html
@@ -13,6 +13,10 @@
             <p style="display: inline"> / </p>
             <a href="/activity/export_csv/{{ course_id }}/">Export CSV</a>
         </ion-card-subtitle>
+        {% else %}
+        <ion-card-subtitle>
+            <a href="/activity/dashboard/{{ course_id }}/?studentid={{ user.id }}"> Tableau de bord</a>
+        </ion-card-subtitle>
         {% endif %}
     <ion-card-title>{{ name }}</ion-card-title>
     {% if instructor %}

--- a/apps/activity/templates/activity/activity_type/course/student_summary.html
+++ b/apps/activity/templates/activity/activity_type/course/student_summary.html
@@ -9,10 +9,28 @@
     </ion-card-header>
     <ion-card-content>
         <section>
+            <b>Votre moyenne sur l'ensemble du cours : {{ '%0.2g' % (mark/5) }} / 20</b><br>
+            <br>
+            moyenne la plus forte : {{ '%0.2g' % (max/5) }} / 20<br>
+            moyenne de tous les élèves : {{ '%0.2g' % (mean/5) }} / 20<br>
+            moyenne la plus faible : {{ '%0.2g' % (min/5) }} / 20<br>
+            <br>
+            {{ nb_more }}
+            {% if nb_more > 1 %}élèves ont {% else %}élève a {% endif %}
+            une meilleure moyenne que vous.<br>
+            {{ nb_less }}
+            {% if nb_less > 1 %}élèves ont {% else %}élève a{% endif %}
+            ont une moyenne plus faible que vous.<br>
+        </section>
+        <section>
             <table>
                 <thead>
                     <tr>
                         <th>Activité</th>
+                        <th>Note/20</th>
+                        <th>N -</th>
+                        <th>Moy</th>
+                        <th>N +</th>
                         <th colspan='100'>Questions</th>
                     </tr>
                 </thead>
@@ -21,6 +39,26 @@
                     <tr>
                         <td class="summary-td">
                             <span>{{ elem.name }}</span>
+                        </td>
+                        <td>
+                            <center>
+                            <b>{{ '%0.2g' % (elem.mark/5) }}</b>
+                            </center>
+                        </td>
+                        <td>
+                            <center>
+                            {{ '%0.2g' % (elem.min/5) }}
+                            </center>
+                        </td>
+                        <td>
+                            <center>
+                            {{ '%0.2g' % (elem.mean/5) }}
+                            </center>
+                        </td>
+                        <td>
+                            <center>
+                            {{ '%0.2g' % (elem.max/5) }}
+                            </center>
                         </td>
                         {% for item in elem.pl %}
                         <center>


### PR DESCRIPTION
The goal of this pull request is refinig the student course dashboard summary on one side 
--> Add mean, min and max marks of each pltp and also global marks
And also, with this patch, student can access to their own summary for each course 
--> For now, just teacher can access that `https://pl.u-pem.fr/activity/dashboard/xxxxx/?studentid=yyyyy` 

![vue_etudiant_course](https://user-images.githubusercontent.com/6042616/135870432-f82081c1-fe5d-497e-9117-13bcf026b140.png)
:

Student has still 403 if they try to see the teacher dashboard, if they try to see the whole summary or if they try to see the summary an other student..
![dashboard_etudiant](https://user-images.githubusercontent.com/6042616/135870659-54c2389d-120c-4aed-b207-bc5364d24ae1.png)
.
