### PR TITLE
Courses Dashbords fix and improvements

### DIFF
--- a/apps/activity/activity_type/course.py
+++ b/apps/activity/activity_type/course.py
@@ -203,7 +203,8 @@ class Course(AbstractActivityType):
         if len(request.POST) == 0 or request.POST['list_group'] == '':
             student_list = activity.student.exclude(id__in=tl_id)
         else:
-            student_list = activity.student.filter(groups__name=request.POST['list_group']).exclude(id__in=tl_id)
+            part_query = activity.student.filter(groups__name=request.POST['list_group'])
+            student_list = part_query.exclude(id__in=tl_id)
 
         grades_query = HighestGrade.objects.filter(activity__in=activities,
                                                    pl__in=all_pl,
@@ -276,7 +277,9 @@ class Course(AbstractActivityType):
 
         average_group = {"average": round((points_group / (5*total_group)), 2)}
         result.append(average_group)
-        indices_student = sorted(list(range(len(result)-1)), key=lambda k: result[k]['activities'][-1]['average'], reverse=True)
+        indices_student = sorted(list(range(len(result)-1)),
+                                 key=lambda k: result[k]['activities'][-1]['average'],
+                                 reverse=True)
 
         return render(request, 'activity/activity_type/course/teacher_dashboard.html', {
             'state': [i for i in State if i != State.ERROR],

--- a/apps/activity/activity_type/course.py
+++ b/apps/activity/activity_type/course.py
@@ -282,7 +282,7 @@ class Course(AbstractActivityType):
             'state': [i for i in State if i != State.ERROR],
             'name': activity.name,
             'student': result,
-            'indices_student' : indices_student,
+            'indices_student': indices_student,
             'range_tp': range(len(activities)),
             'course_id': activity.id,
             'groups': groups,

--- a/apps/activity/templates/activity/activity_type/course/student_summary.html
+++ b/apps/activity/templates/activity/activity_type/course/student_summary.html
@@ -9,11 +9,11 @@
     </ion-card-header>
     <ion-card-content>
         <section>
-            <b>Votre moyenne sur l'ensemble du cours : {{ '%0.2g' % (mark/5) }} / 20</b><br>
+            <b>Votre moyenne sur l'ensemble du cours : {{ mark }} / 20</b><br>
             <br>
-            moyenne la plus forte : {{ '%0.2g' % (max/5) }} / 20<br>
-            moyenne de tous les élèves : {{ '%0.2g' % (mean/5) }} / 20<br>
-            moyenne la plus faible : {{ '%0.2g' % (min/5) }} / 20<br>
+            moyenne la plus forte : {{ max }} / 20<br>
+            moyenne de tous les élèves : {{ mean }} / 20<br>
+            moyenne la plus faible : {{ min }} / 20<br>
             <br>
             {{ nb_more }}
             {% if nb_more > 1 %}élèves ont {% else %}élève a {% endif %}
@@ -42,22 +42,22 @@
                         </td>
                         <td>
                             <center>
-                            <b>{{ '%0.2g' % (elem.mark/5) }}</b>
+                            <b>{{ elem.mark }}</b>
                             </center>
                         </td>
                         <td>
                             <center>
-                            {{ '%0.2g' % (elem.min/5) }}
+                            {{ elem.min }}
                             </center>
                         </td>
                         <td>
                             <center>
-                            {{ '%0.2g' % (elem.mean/5) }}
+                            {{ elem.mean }}
                             </center>
                         </td>
                         <td>
                             <center>
-                            {{ '%0.2g' % (elem.max/5) }}
+                            {{ elem.max }}
                             </center>
                         </td>
                         {% for item in elem.pl %}

--- a/apps/activity/templates/activity/activity_type/course/teacher_dashboard.html
+++ b/apps/activity/templates/activity/activity_type/course/teacher_dashboard.html
@@ -21,16 +21,26 @@
 
     <ion-card-content>
         <section>
+            <p>
+                Seulement les élèves apparaissent dans la table suivante. Les moyennes sont calculées ici en
+                faisant une somme des notes, pour chaque élève, sur tous les exercices finaux puis en divisant
+                par le nombre total d'exercices déployés sur la matière. Les PLTP n'ont donc pas tous un poids
+                équivalent : par exemple, un PLTP avec 10 exercices aura un poids deux fois plus important
+                qu'un PLTP contenant 5 exercices. Les notes des utilisateurs enseignants n'entrent pas dans la
+                moyenne totale sur tous les utilisateurs du cours.
+            </p>
+            <br>
             <table>
                 <thead>
                     <tr>
                         <th>Élève</th>
-                        <th colspan="100">Activités</th>
+                        <th colspan="{{student[0].activities|length }}">Activités</th>
                         <th>Notes : {{ student[-1].average }}</th>
                     </tr>
                 </thead>
                 <tbody>
-                {% for stud in student[0:-1] %}
+                {% for ind in indices_student %}
+                {% set stud=student[ind] %}
                     <tr>
                         <td>
                             <a href="/activity/dashboard/{{ course_id }}/?studentid={{ stud.object.id }}">


### PR DESCRIPTION
In this branch :

 * fix the average mark calculation to be the mean of all exercises everywhere
 * fix the colspan and vertical alignment of average mark
 * Improve complexity of student dashboard calculation (reduce number of django request)
 * Improve the display of marks by using round( ..., 2 ) everywhere and {{ ... }} in template (no more "%0.2g" format)
 * All dashobards (teacher and student display same marks)
 * student are ordered by average global mark on teacher dashboard
 * teachers (and their marks) are no more displayed in teacher dashboard
 
This need to be hugely tested before placing in production....