### PR TITLE
fix jinja2 version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-markdown-app
 django-taggit==2.1.0
 dj-database-url==0.5.0
 gunicorn
-Jinja2
+Jinja2==3.0.2
 jsonfield
 markdown<3.1,>=2.6
 markupsafe==2.0.1


### PR DESCRIPTION
freeze jinja2 version to avoid incompatibilities with newer 3.1 version of jinja